### PR TITLE
Added support for terraform-provider-oci

### DIFF
--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -31,6 +31,7 @@ PROVIDER_FILTERS = [
     'integrations/github',
     # 'jfrog/artifactory',  # Buggy
     'microsoft/azuredevops',
+    'oracle/oci',
     'PagerDuty/pagerduty',
     'splunk/splunk',
     'splunk/victorops',

--- a/scripts/test_render.py
+++ b/scripts/test_render.py
@@ -28,6 +28,7 @@ class TestDeriveResourceName(ut.TestCase):
             ('nexus_repository_pypi_group', 'Resource nexus_repository_pypi_group', 'Resource nexus_repository_pypi_group', ''),
             ('azuredevops_serviceendpoint_github', 'AzureDevops: Data Source: azuredevops_serviceendpoint_github', 'Data Source : azuredevops_serviceendpoint_github', ''),
             ('google_cloud_run_v2_job_iam', '', '', '/Users/redacted/src/gh/roberth-k/dash-docset-terraform/.build/1.3.9.230305/Terraform.docset/Contents/Resources/Documents/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job_iam.html'),
+            ('oci_core_instance', 'Oracle: oci_core_instance', 'oci_core_instance', '')
         ]
 
         for expect, metadata, title, output_file in test_cases:

--- a/version/providers
+++ b/version/providers
@@ -34,6 +34,7 @@ hashicorp/kubernetes https://github.com/hashicorp/terraform-provider-kubernetes 
 hashicorp/local https://github.com/hashicorp/terraform-provider-local v2.4.0
 hashicorp/nomad https://github.com/hashicorp/terraform-provider-nomad v1.4.19
 hashicorp/null https://github.com/hashicorp/terraform-provider-null v3.2.1
+hashicorp/oci https://github.com/oracle/terraform-provider-oci v4.114.0
 hashicorp/opc https://github.com/terraform-providers/terraform-provider-opc v1.4.1
 hashicorp/oraclepaas https://github.com/terraform-providers/terraform-provider-oraclepaas v1.5.3
 hashicorp/random https://github.com/hashicorp/terraform-provider-random v3.4.3

--- a/version/providers
+++ b/version/providers
@@ -34,7 +34,6 @@ hashicorp/kubernetes https://github.com/hashicorp/terraform-provider-kubernetes 
 hashicorp/local https://github.com/hashicorp/terraform-provider-local v2.4.0
 hashicorp/nomad https://github.com/hashicorp/terraform-provider-nomad v1.4.19
 hashicorp/null https://github.com/hashicorp/terraform-provider-null v3.2.1
-hashicorp/oci https://github.com/oracle/terraform-provider-oci v4.114.0
 hashicorp/opc https://github.com/terraform-providers/terraform-provider-opc v1.4.1
 hashicorp/oraclepaas https://github.com/terraform-providers/terraform-provider-oraclepaas v1.5.3
 hashicorp/random https://github.com/hashicorp/terraform-provider-random v3.4.3
@@ -52,6 +51,7 @@ honeycombio/honeycombio https://github.com/honeycombio/terraform-provider-honeyc
 integrations/github https://github.com/integrations/terraform-provider-github v5.18.3
 microsoft/azuredevops https://github.com/microsoft/terraform-provider-azuredevops v0.4.0
 PagerDuty/pagerduty https://github.com/PagerDuty/terraform-provider-pagerduty v2.11.2
+oracle/oci https://github.com/oracle/terraform-provider-oci v4.115.0
 splunk/splunk https://github.com/splunk/terraform-provider-splunk v1.4.18
 splunk/victorops https://github.com/splunk/terraform-provider-victorops v0.1.4
 terraform-provider-openstack/openstack https://github.com/terraform-provider-openstack/terraform-provider-openstack v1.51.1


### PR DESCRIPTION
This PR will add support for the terraform-provider-oci. I also added the oci_core_instance resource as a test in test_render.py. Please review and let me know if there are additional requirements to merge. Appreciate your maintaining this docset. 