### PR TITLE
Add Yandex Cloud provider, fix find warning

### DIFF
--- a/scripts/makefile.sh
+++ b/scripts/makefile.sh
@@ -86,7 +86,7 @@ echo "TARGETS :="
 
 emit_terraform_rules
 
-find "$srcdir/providers" -type d -mindepth 2 -maxdepth 2 -print0 \
+find "$srcdir/providers" -mindepth 2 -maxdepth 2 -type d -print0 \
 | while read -d $'\0' provider_src
 do
     emit_provider_rules $provider_src

--- a/scripts/providers.py
+++ b/scripts/providers.py
@@ -39,6 +39,7 @@ PROVIDER_FILTERS = [
     'splunk/splunk',
     'splunk/victorops',
     'terraform-provider-openstack/openstack',
+    'yandex-cloud/yandex',
 ]
 
 

--- a/scripts/test_render.py
+++ b/scripts/test_render.py
@@ -28,7 +28,8 @@ class TestDeriveResourceName(ut.TestCase):
             ('nexus_repository_pypi_group', 'Resource nexus_repository_pypi_group', 'Resource nexus_repository_pypi_group', ''),
             ('azuredevops_serviceendpoint_github', 'AzureDevops: Data Source: azuredevops_serviceendpoint_github', 'Data Source : azuredevops_serviceendpoint_github', ''),
             ('google_cloud_run_v2_job_iam', '', '', '/Users/redacted/src/gh/roberth-k/dash-docset-terraform/.build/1.3.9.230305/Terraform.docset/Contents/Resources/Documents/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_job_iam.html'),
-            ('oci_core_instance', 'Oracle: oci_core_instance', 'oci_core_instance', '')
+            ('oci_core_instance', 'Oracle: oci_core_instance', 'oci_core_instance', ''),
+            ('ydb_database_serverless', 'yandex_ydb_database_serverless', 'ydb_database_serverless', ''),
         ]
 
         for expect, metadata, title, output_file in test_cases:

--- a/version/providers
+++ b/version/providers
@@ -50,3 +50,4 @@ PagerDuty/pagerduty https://github.com/PagerDuty/terraform-provider-pagerduty v3
 splunk/splunk https://github.com/splunk/terraform-provider-splunk v1.4.22
 splunk/victorops https://github.com/splunk/terraform-provider-victorops v0.1.4
 terraform-provider-openstack/openstack https://github.com/terraform-provider-openstack/terraform-provider-openstack v1.53.0
+yandex-cloud/yandex https://github.com/yandex-cloud/terraform-provider-yandex v0.104.0


### PR DESCRIPTION
Add `yandex-cloud/yandex` provider. Also fix the following warning:

> find: warning: you have specified the global option -mindepth after the argument -type, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.