### PR TITLE
ci: revamp release action, update action versions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           name: Terraform.tgz
 
-      - uses: softprops/gh-release@v2
+      - uses: softprops/action-gh-release@v2
         with:
           files: Terraform.tgz
           tag_name: ${{ github.ref_name }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,15 +8,15 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - run: make test/unit
       - run: make -j$(( $(nproc) + 1 ))
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: Terraform.tgz
           path: .build/latest/Terraform.tgz
@@ -24,42 +24,17 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - build
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: Terraform.tgz
 
-      - name: create draft release
-        uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_USER_ACCESS_TOKEN }}
+      - uses: softprops/gh-release@v2
         with:
+          files: Terraform.tgz
           tag_name: ${{ github.ref_name }}
-          release_name: ${{ github.ref_name }}
-          draft: true
-
-      - name: upload docset to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_USER_ACCESS_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: Terraform.tgz
-          asset_name: Terraform.tgz
-          asset_content_type: application/gzip
-
-      - name: publish release
-        env:
-          GITHUB_TOKEN: ${{ secrets.CI_USER_ACCESS_TOKEN }}
-        run: |
-          curl \
-            --show-error --fail -i \
-            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/${{ steps.create_release.outputs.id }}" \
-            -XPATCH \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            -d '{"draft": false}'
+          name: ${{ github.ref_name }}
+          token: ${{ secrets.CI_USER_ACCESS_TOKEN }}


### PR DESCRIPTION
Currently, tagged releases are failing to run due to the use of deprecated actions. Additionally, the [actions/upload-release-asset](https://github.com/actions/upload-release-asset) action used for attaching files to a release is no longer developed and has been archived.

This PR updates each action in the build/release workflow to the latest available versions and switches to the [softprops/action-gh-release](https://github.com/softprops/action-gh-release) action for creating the release with the associated docset artifact.

Partially resolves #11